### PR TITLE
Code typo for RADIO constant

### DIFF
--- a/DetailView.php
+++ b/DetailView.php
@@ -16,6 +16,8 @@ use yii\helpers\Json;
 use yii\helpers\Url;
 use yii\web\JsExpression;
 use yii\widgets\ActiveForm;
+use kartik\helpers\Html;
+use kartik\base\Config;
 
 /**
  * Enhances the Yii DetailView widget with various options to include Bootstrap

--- a/DetailView.php
+++ b/DetailView.php
@@ -65,7 +65,8 @@ class DetailView extends \yii\widgets\DetailView
     /**
      * Edit input types
      */
-    // input types    const INPUT_RADIO = 'radio';
+    // input types    
+    const INPUT_RADIO = 'radio';
     const INPUT_LIST_BOX = 'listBox';
     const INPUT_DROPDOWN_LIST = 'dropDownList';
     const INPUT_CHECKBOX_LIST = 'checkboxList';


### PR DESCRIPTION
uncommenting on line 68-69 const INPUT_RADIO = 'radio'; because self::INPUT_RADIO is not defined otherwise