### PR TITLE
Auto set to edit mode when model has validation errors.

### DIFF
--- a/DetailView.php
+++ b/DetailView.php
@@ -501,6 +501,10 @@ class DetailView extends \yii\widgets\DetailView
     protected function validateDisplay()
     {
         $none = 'display:none';
+        if(sizeof($this->model->getErrors())>0)
+        {
+        	$this->mode = self::MODE_EDIT;
+        }
         if ($this->mode === self::MODE_EDIT) {
             Html::addCssClass($this->container, 'kv-edit-mode');
             Html::addCssStyle($this->viewAttributeContainer, $none);


### PR DESCRIPTION
If an error occurs during the Update Validation on server the detail view should reload in the edit view to show and easier fix the error. Currently the view always load in the “view” mode.