### PR TITLE
fix for missing assets

### DIFF
--- a/DetailView.php
+++ b/DetailView.php
@@ -1000,6 +1000,7 @@ class DetailView extends \yii\widgets\DetailView
         }
         $this->registerPlugin($this->_pluginName, $id);
         if ($this->tooltips) {
+            $view->registerAssetBundle('yii\bootstrap\BootstrapPluginAsset');
             $view->registerJs($id . '.find("[data-toggle=tooltip]").tooltip();');
         }
     }
@@ -1082,7 +1083,6 @@ class DetailView extends \yii\widgets\DetailView
         }
         if (isset($attribute['visible']) && !$attribute['visible'] && !$child) {
             unset($this->attributes[$i]);
-            continue;
         }
         if (!isset($attribute['format'])) {
             $attribute['format'] = 'text';


### PR DESCRIPTION
Added missing yii\bootstrap\BootstrapPluginAsset when tooltips=true, see issue https://github.com/kartik-v/yii2-detail-view/issues/78
Removed unnecessary continue in parseAttributeItem method which is not in while or for stement