### PR TITLE
Allow configuration of ActiveForm class

### DIFF
--- a/DetailView.php
+++ b/DetailView.php
@@ -17,7 +17,7 @@ use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
 use yii\helpers\Url;
 use yii\web\JsExpression;
-use yii\widgets\ActiveForm;
+use kartik\form\ActiveForm;
 use kartik\base\Config;
 use kartik\helpers\Html;
 


### PR DESCRIPTION
Changed yii\widgets\ActiveForm to kartik\form\ActiveForm so that fieldConfig options for 'addon' attribute would work. 

http://demos.krajee.com/widget-details/active-field

May need to update the required dependencies in composer.