### PR TITLE
Adjust required version of yii2-helpers to 1.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "kartik-v/yii2-krajee-base": "~1.7",
-        "kartik-v/yii2-helpers": "~1.3"
+        "kartik-v/yii2-helpers": "~1.3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adjust required version of yii2-helpers to 1.3.5 to address https://github.com/kartik-v/yii2-detail-view/issues/105