### PR TITLE
Dependency for yii2-helpers to recommended version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "kartik-v/yii2-krajee-base": "~1.7",
-        "kartik-v/yii2-helpers": "~1.3.5",
+        "kartik-v/yii2-helpers": "dev-master",
         "kartik-v/yii2-dialog": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
yii2-helpers 1.3.5 is a little bit outdated and not the recommended version anymore.
if requiry of yii2-helpers 1.3.5 is not met, detail-view downgrates to ancient version 1.7.1