### PR TITLE
Fix for issue #132: {buttons} tag defined in mainTemplate is not working

### DIFF
--- a/DetailView.php
+++ b/DetailView.php
@@ -767,8 +767,8 @@ class DetailView extends YiiDetailView
             $output = $this->renderPanel($output);
         }
         $output = strtr(
-            $this->mainTemplate,
-            ['{detail}' => Html::tag('div', $output, $this->container)]
+            Html::tag('div', $this->mainTemplate, $this->container),
+            ['{detail}' => $output]
         );
         Html::addCssClass($this->viewButtonsContainer, 'kv-buttons-1');
         $buttons = Html::tag('span', $this->renderButtons(1), $this->viewButtonsContainer);


### PR DESCRIPTION
## Scope
This pull request includes a

- [ x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-detail-view/blob/master/CHANGE.md)):

- Render {buttons} tag defined in mainTemplate inside instead of outside main container.


## Related Issues
If this is related to an existing ticket, include a link to it as well.

See issue #132