### PR TITLE
Fix missing implementation to use INPUT_CHECKBOX_BUTTON_GROUP and INP…

### DIFF
--- a/DetailView.php
+++ b/DetailView.php
@@ -278,6 +278,8 @@ class DetailView extends YiiDetailView
         self::INPUT_HTML5 => 'input',
         self::INPUT_FILE => 'fileInput',
         self::INPUT_WIDGET => 'widget',
+        self::INPUT_CHECKBOX_BUTTON_GROUP => 'checkboxButtonGroup',
+        self::INPUT_RADIO_BUTTON_GROUP => 'radioButtonGroup',
     ];
 
     // dropdown inputs
@@ -286,6 +288,8 @@ class DetailView extends YiiDetailView
         self::INPUT_DROPDOWN_LIST => 'dropDownList',
         self::INPUT_CHECKBOX_LIST => 'checkboxList',
         self::INPUT_RADIO_LIST => 'radioList',
+        self::INPUT_CHECKBOX_BUTTON_GROUP => 'checkboxButtonGroup',
+        self::INPUT_RADIO_BUTTON_GROUP => 'radioButtonGroup',
     ];
 
     /**
@@ -496,7 +500,7 @@ class DetailView extends YiiDetailView
     /**
      * @var string the ActiveForm widget class
      */
-    public $formClass = 'yii\widgets\ActiveForm';
+    public $formClass = '\kartik\form\ActiveForm';
 
     /**
      * @var array the panel settings. If this is set, the grid widget


### PR DESCRIPTION
This pull reference to the issue #142
Implementing a detailview form using INPUT_CHECKBOX_BUTTON_GROUP or INPUT_RADIO_BUTTON_GROUP throw the error
Invalid input type '{$input}' defined for the attribute.....
It seem that the implementation in incomplete.
The two widget need to be inserted in both $_inputsList and $_dropDownInputs array.
The form class to be used must be \kartik\form\ActiveForm (where the two are defined) and not yii\widgets\ActiveForm