### PR TITLE
Add support for unicode attribute names.

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,9 @@
 Change Log: `yii2-detail-view`
 ==============================
 
+## Version 1.7.7
+**Date:** 
+- Add support for unicode characters in attribute names (sammousa)
 ## Version 1.7.6
 
 **Date:** 14-Dec-2016

--- a/DetailView.php
+++ b/DetailView.php
@@ -1252,7 +1252,7 @@ class DetailView extends YiiDetailView
     protected function parseAttributeItem($attribute)
     {
         if (is_string($attribute)) {
-            if (!preg_match('/^([\w\.]+)(:(\w*))?(:(.*))?$/', $attribute, $matches)) {
+            if (!preg_match('/^([^:]+)(:(\w*))?(:(.*))?$/', $attribute, $matches)) {
                 throw new InvalidConfigException(
                     'The attribute must be specified in the format of "attribute", "attribute:format" or ' .
                     '"attribute:format:label"'


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [x] New feature

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-detail-view/blob/master/CHANGE.md)):

- A fix from Yii was ported to support Unicode characters in attribute names.

## Related Issues
 yiisoft/yii2#13243