### PR TITLE
Update Italian translations

### DIFF
--- a/messages/it/kvdetail.php
+++ b/messages/it/kvdetail.php
@@ -17,7 +17,7 @@
  * NOTE: this file must be saved in UTF-8 encoding.
  */
 return [
-    'Cancel Changes' => '',
+    'Cancel Changes' => 'Annulla Modifiche',
     'Are you sure you want to delete this item?' => 'Sei sicuro di volere eliminare questo elemento?',
     'Delete' => 'Elimina',
     'Save' => 'Salva',


### PR DESCRIPTION
"Cancel Changes" translation to Italian missing.

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [X] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-detail-view/blob/master/CHANGE.md)):

-Added translation for "Cancel Changes" message to "it".


## Related Issues
"Cancel Changes" translation missing.