### PR TITLE
KISTSP-704: Initial VET7 DetailView fork setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+## 1.8.7-vet7.1
+
+- Created VET7.well-specific fork of `kartik-v/yii2-detail-view`
+- Changed Composer package name to `vet7/yii2-vet7-detail-view`
+- Changed PHP namespace from `kartik\detail` to `vet7\detail`
+- Preserved original license and attribution

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **VET7.well fork note:** This repository is a VET7.well-specific public fork of `kartik-v/yii2-detail-view`. It exists to support isolated DetailView customizations for selected KIS pages: Case, Pet/Animal and PetOwner. The original upstream package remains used elsewhere in the application. The fork is intentionally kept small and focused.
+
 <h1 align="center">
     <a href="http://demos.krajee.com" title="Krajee Demos" target="_blank">
         <img src="http://kartik-v.github.io/bootstrap-fileinput-samples/samples/krajee-logo-b.png" alt="Krajee Logo"/>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
-  "name": "kartik-v/yii2-detail-view",
-  "description": "Enhanced Yii 2 Detail View widget with special Bootstrap styles, ability to edit data, and more.",
+  "name": "vet7/yii2-vet7-detail-view",
+  "description": "VET7.well fork of Enhanced Yii 2 Detail View widget (based on kartik-v/yii2-detail-view).",
+  "version": "1.8.7.1",
   "keywords": [
     "yii2",
     "extension",
@@ -8,7 +9,8 @@
     "detail",
     "grid",
     "form",
-    "detail view"
+    "detail view",
+    "vet7"
   ],
   "homepage": "https://github.com/kartik-v/yii2-detail-view",
   "type": "yii2-extension",
@@ -27,12 +29,13 @@
   },
   "autoload": {
     "psr-4": {
-      "kartik\\detail\\": "src"
+      "vet7\\detail\\": "src"
     }
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.8.x-dev"
+      "dev-master": "1.8.x-dev",
+      "dev-vet7-initial-setup": "1.8.7-vet7.x-dev"
     }
   }
 }

--- a/src/DetailView.php
+++ b/src/DetailView.php
@@ -7,7 +7,7 @@
  * @version   1.8.7
  */
 
-namespace kartik\detail;
+namespace vet7\detail;
 
 use Closure;
 use Exception;

--- a/src/DetailViewAsset.php
+++ b/src/DetailViewAsset.php
@@ -7,7 +7,7 @@
  * @version   1.8.7
  */
 
-namespace kartik\detail;
+namespace vet7\detail;
 
 use kartik\base\AssetBundle;
 


### PR DESCRIPTION
This PR prepares the VET7-specific fork of `kartik-v/yii2-detail-view` for KISTSP-704.

Changes:
- changed Composer package name to `vet7/yii2-vet7-detail-view`
- changed PHP namespace from `kartik\detail` to `vet7\detail`
- preserved original license and attribution
- added VET7-specific README note
- added CHANGELOG.md with initial fork release notes

This fork will be used only for Case, Pet/Animal and PetOwner DetailView pages in the main Yii2 project. The original `kartik-v/yii2-detail-view` package remains used everywhere else.